### PR TITLE
feat: Toolbar 및 Icon 컴포넌트 작업

### DIFF
--- a/components/Icon/Icon.style.ts
+++ b/components/Icon/Icon.style.ts
@@ -1,0 +1,32 @@
+import styled, { css } from "styled-components";
+
+export const StyledIcon = styled.span<{
+  size?: number;
+  active?: boolean;
+}>`
+  // default
+  display: inline-flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all 0.4s; // FIXME
+
+  // active & inactive
+  color: ${(props) => props.active? props.theme.colors.NAVY : props.theme.colors.WHITE_300};
+  background-color: ${(props) => props.active? props.theme.colors.WHITE_300 : null};
+
+  // size
+  ${(props) => props.size && css`  
+    width: ${props.size}px;
+    height: ${props.size}px;
+    border-radius: ${props.size / 2}px;
+
+    svg {
+      width: ${props.size-16}px;
+      height: ${props.size-16}px;
+    }
+  `}
+  
+`;
+

--- a/components/Icon/Icon.tsx
+++ b/components/Icon/Icon.tsx
@@ -1,0 +1,24 @@
+import { useRouter } from "next/router";
+import { ReactElement } from "react";
+import { StyledIcon } from "./Icon.style";
+
+interface Props {
+  children: ReactElement;
+  size: number;
+  route?: string;
+}
+
+const Icon = ({children, ...props}: Props) => {  
+  const router = useRouter();
+
+  return (
+    <StyledIcon 
+      size={props.size}
+      active={props.route === router.route}
+    >
+      {children}
+    </StyledIcon>
+  )
+};
+
+export default Icon;

--- a/components/Toolbar/Toolbar.style.ts
+++ b/components/Toolbar/Toolbar.style.ts
@@ -1,8 +1,37 @@
 import styled from "styled-components";
 
-export const StyledToolbar = styled.header`
+export const StyledToolbar = styled.footer`
+  padding: 8px 24px 0 24px;
   width: 100%;
   height: 80px;
   min-height: 80px;
   max-height: 80px;
+  
+  background-color: ${props => props.theme.colors.NAVY};
+`;
+
+export const StyledMain = styled.nav`
+  width: 342px;
+  height: 48px;
+`;
+
+export const StyledUl = styled.ul`
+  width: 100%;
+  height: 100%;
+
+  display: inline-flex;
+  flex-directrion: row;
+  flex-gap: 25px;
+  gap: 25px;
+`;
+
+export const StyledLi = styled.li`
+  width: 48px;
+  height: 48px;
+
+  display: inline-flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+
 `;

--- a/components/Toolbar/Toolbar.tsx
+++ b/components/Toolbar/Toolbar.tsx
@@ -1,26 +1,56 @@
-import { StyledToolbar } from "./Toolbar.style";
-
-const Toolbar = (props: any) => {
-  return (
-    <>
-      {/* {props.default? <DefaultToolbar /> : <InvisibleToolbar />} */}
-      <DefaultToolbar /> 
-    </>
-  );
+import Link from "next/link";
+import Icon from "@components/Icon/Icon";
+import { IconType } from "react-icons";
+import { 
+  AiOutlineBook, 
+  AiOutlineEdit, 
+  AiOutlineHome, 
+  AiOutlineSearch, 
+  AiOutlineSetting,
+} from "react-icons/ai"; 
+import { 
+  StyledLi, 
+  StyledMain, 
+  StyledToolbar, 
+  StyledUl 
+} from "./Toolbar.style";
+interface NavListsType {
+  id: number;
+  name?: string;
+  size: number;
+  iconName: IconType;
+  route: string;
 }
+// FIXME: enum ?
+const NavLists: NavListsType[] = [
+  {id: 0, name: 'home', size: 48, iconName: AiOutlineHome, route: '/'},
+  {id: 1, name: 'search', size: 48, iconName: AiOutlineSearch, route: '/search'},
+  {id: 2, name: 'write', size: 48, iconName: AiOutlineEdit, route: '/write'},
+  {id: 3, name: 'bookmark', size: 48, iconName: AiOutlineBook, route: '/bookmark'},
+  {id: 4, name: 'mypage', size: 48,  iconName: AiOutlineSetting, route: '/mypage'},
+];
 
-const DefaultToolbar = () => {
+const Toolbar = () => {
+
   return (
     <StyledToolbar>
-      default toolbar
-    </StyledToolbar>
-  );
-}
-
-const InvisibleToolbar = () => {
-  return (
-    <StyledToolbar>
-      exceptional toolbar
+      <StyledMain>
+        <StyledUl>
+        {
+          NavLists.map((list) => {
+            return (
+              <Link key={list.id} href={list.route}>
+                <StyledLi>
+                  <Icon {...list}>
+                    <list.iconName />
+                  </Icon>
+                </StyledLi>
+              </Link>
+            );
+          })
+        }
+        </StyledUl>
+      </StyledMain>
     </StyledToolbar>
   );
 }


### PR DESCRIPTION
### AS-IS


### TO-BE
하단 Toolbar와 각 탭메뉴 아이콘을 보여줄 Icon 컴포넌트를 작업하였습니다.
-  [해당 부분](https://github.com/sukyoungshin/blog/commit/be06b08b68cf76188011a58d71c78ccd2c5a37da#diff-e7b90903ad77b710c90e3e5da5600aa6618e0454bc738adbff7cb277c3d481a0R24-R31:~:text=name%3A%20%27-,home,-%27%2C%20size)의 형태를 배열에서 enum으로 바꾸고 싶은데, 아직 enum에 대한 지식이 부족하여 찾아보고 차후 변경할 예정입니다.
